### PR TITLE
Add importer for dns domain resource

### DIFF
--- a/vultr/resource_dns_domain.go
+++ b/vultr/resource_dns_domain.go
@@ -12,6 +12,9 @@ func resourceDNSDomain() *schema.Resource {
 		Create: resourceDNSDomainCreate,
 		Read:   resourceDNSDomainRead,
 		Delete: resourceDNSDomainDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"domain": {


### PR DESCRIPTION
Hey @squat! Figured I'd take a shot at #11. PR is short I know but I figured we'd do the importer per resource so we can test properly instead of doing it in one go. Let me know what you think.

Test Plan:

Given a .tf file:

``` HCL
provider "vultr" {
  api_key = "<api-key>"
}

resource "vultr_dns_domain" "example" {
  domain = "randomdomain.com"
  ip     = "10.0.0.1"
}

```

Running `terraform import vultr_dns_domain.example randomdomain.com` yields:

``` bash
vultr_dns_domain.example: Importing from ID "randomdomain.com"...
vultr_dns_domain.example: Import complete!
  Imported vultr_dns_domain (ID: randomdomain.com)
vultr_dns_domain.example: Refreshing state... (ID: randomdomain.com)

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```

Running `terraform plan` yields:

``` bash
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

vultr_dns_domain.example: Refreshing state... (ID: randomdomain.com)

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

-/+ vultr_dns_domain.example (new resource required)
      id:     "randomdomain.com" => <computed> (forces new resource)
      domain: "" => "randomdomain.com" (forces new resource)
      ip:     "" => "10.0.0.1" (forces new resource)


Plan: 1 to add, 0 to change, 1 to destroy.
```
We can see that terraform intends to destroy the imported domain and create a new one since there is no `PATCH` endpoint.

Also ran:

- `make test`
- `make fmt`
- `make lint`