### PR TITLE
Domain set fields

### DIFF
--- a/vultr/resource_dns_domain.go
+++ b/vultr/resource_dns_domain.go
@@ -3,7 +3,9 @@ package vultr
 import (
 	"fmt"
 	"log"
+	"strings"
 
+	"github.com/JamesClonk/vultr/lib"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -55,14 +57,47 @@ func resourceDNSDomainRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error getting DNS domains: %v", err)
 	}
 
+	var dnsDomain *lib.DNSDomain
 	for i := range dnsDomains {
 		if dnsDomains[i].Domain == d.Id() {
-			return nil
+			dnsDomain = &dnsDomains[i]
+			break
 		}
 	}
 
-	log.Printf("[WARN] Removing DNS domain (%s) because it is gone", d.Id())
-	d.SetId("")
+	if dnsDomain == nil {
+		log.Printf("[WARN] Removing DNS domain (%s) because it is gone", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	// Find the default record for the domain.
+	records, err := client.GetDNSRecords(dnsDomain.Domain)
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "Invalid domain.") {
+			log.Printf("[WARN] Removing DNS domain (%s) because it has no default record", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error getting DNS records for DNS domain (%s): %v", d.Id(), err)
+	}
+
+	var record *lib.DNSRecord
+	for i := range records {
+		if records[i].Type == "A" && records[i].Name == "" {
+			record = &records[i]
+			break
+		}
+	}
+
+	if record == nil {
+		log.Printf("[WARN] Removing DNS domain (%s) because it has no default record", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("domain", dnsDomain.Domain)
+	d.Set("ip", record.Data)
 
 	return nil
 }

--- a/vultr/resource_dns_record.go
+++ b/vultr/resource_dns_record.go
@@ -114,9 +114,9 @@ func resourceDNSRecordRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	var record *lib.DNSRecord
-	for _, r := range records {
-		if r.RecordID == id {
-			record = &r
+	for i := range records {
+		if records[i].RecordID == id {
+			record = &records[i]
 			break
 		}
 	}

--- a/vultr/resource_ssh_key.go
+++ b/vultr/resource_ssh_key.go
@@ -56,17 +56,19 @@ func resourceSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error getting SSH keys: %v", err)
 	}
+
 	var key *lib.SSHKey
 	for i := range keys {
 		if keys[i].ID == d.Id() {
 			key = &keys[i]
 			break
 		}
-		if i == len(keys)-1 {
-			log.Printf("[WARN] Removing SSH key (%s) because it is gone", d.Id())
-			d.SetId("")
-			return nil
-		}
+	}
+
+	if key == nil {
+		log.Printf("[WARN] Removing SSH key (%s) because it is gone", d.Id())
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("name", key.Name)


### PR DESCRIPTION
Fix a bug where reading a DNS domain from the API does not set the necessary fields on the domain struct. Also, standardize the for loops in several resources for consistency.

This should fix an issue in #19 where planning after importing a DNS domain always results in resource churn.

cc @teh-username 