### PR TITLE
Add importer for ssh resource

### DIFF
--- a/vultr/resource_ssh_key.go
+++ b/vultr/resource_ssh_key.go
@@ -15,6 +15,9 @@ func resourceSSHKey() *schema.Resource {
 		Read:   resourceSSHKeyRead,
 		Update: resourceSSHKeyUpdate,
 		Delete: resourceSSHKeyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {


### PR DESCRIPTION
Test Plan:

Given a .tf file:
``` HCL
provider "vultr" {
  api_key = "<api-key>"
}

resource "vultr_ssh_key" "example" {
  name       = "example"
  public_key = "${file("/path/to/key")}"
}
```

Running `terraform import vultr_ssh_key.example SSHKEYID` yields:

``` bash
vultr_ssh_key.example: Importing from ID "SSHKEYID"...
vultr_ssh_key.example: Import complete!
  Imported vultr_ssh_key (ID: SSHKEYID)
vultr_ssh_key.example: Refreshing state... (ID: SSHKEYID)

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```

Running `terraform plan` immediately yields:

``` bash
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

vultr_ssh_key.example: Refreshing state... (ID: SSHKEYID)

------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```