### PR TITLE
Add importer for startup script

### DIFF
--- a/vultr/resource_startup_script.go
+++ b/vultr/resource_startup_script.go
@@ -14,6 +14,9 @@ func resourceStartupScript() *schema.Resource {
 		Read:   resourceStartupScriptRead,
 		Update: resourceStartupScriptUpdate,
 		Delete: resourceStartupScriptDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"content": {
@@ -65,6 +68,12 @@ func resourceStartupScriptRead(d *schema.ResourceData, meta interface{}) error {
 	script, err := client.GetStartupScript(d.Id())
 	if err != nil {
 		return fmt.Errorf("Error getting startup script (%s): %v", d.Id(), err)
+	}
+
+	if script == (lib.StartupScript{}) {
+		log.Printf("[WARN] Removing startup script (%s) because it is gone", d.Id())
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("content", script.Content)


### PR DESCRIPTION
Test Plan:

Given .tf file:
``` HCL
provider "vultr" {
  api_key = "<api-key>"
}

resource "vultr_startup_script" "example" {
  content   = "#!/bin/bash echo Hello World > /root/hello"
  name      = "example"
  type      = "boot"
}
```

Running `terraform import vultr_startup_script.example SCRIPTID` yields:

``` bash
vultr_startup_script.example: Importing from ID "SCRIPTID"...
vultr_startup_script.example: Import complete!
  Imported vultr_startup_script (ID: SCRIPTID)
vultr_startup_script.example: Refreshing state... (ID: SCRIPTID)

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```

Running `terraform plan` yields:

``` bash
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

vultr_startup_script.example: Refreshing state... (ID: SCRIPTID)

------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```