### PR TITLE
Added an option to log API calls when using TF_LOG=DEBUG

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 783164ca20f740e33d7e2f14ae650357f4812e4580dba95677ae4af7f819d2fa
-updated: 2017-10-27T14:19:24.205166481+02:00
+hash: d901ca8b8e15b75d689d896110263e15cf7c27c9378ce33537b07b4ee7054879
+updated: 2018-01-03T19:48:20.673845872-05:00
 imports:
 - name: github.com/apparentlymart/go-cidr
   version: a3ebdb999b831ecb6ab8a226e31b07b2b9061c47
@@ -99,7 +99,7 @@ imports:
 - name: github.com/hashicorp/yamux
   version: d1caa6c97c9fc1cc9e83bbe34d0603f9ff0ce8bd
 - name: github.com/JamesClonk/vultr
-  version: e5dad9a80e61623e1da10706f486596f77469049
+  version: fa1c0367800db75e4d10d0ec90c49a8731670224
   subpackages:
   - lib
 - name: github.com/jmespath/go-jmespath

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,6 +3,7 @@ import:
 - package: github.com/JamesClonk/vultr
   subpackages:
   - lib
+  version: 1.15.0
 - package: github.com/fatih/structs
 - package: github.com/hashicorp/terraform
   subpackages:

--- a/vendor/github.com/JamesClonk/vultr/.gitignore
+++ b/vendor/github.com/JamesClonk/vultr/.gitignore
@@ -23,5 +23,7 @@ _testmain.go
 *.test
 *.prof
 
+# release
+dist
 # bin
 vultr

--- a/vendor/github.com/JamesClonk/vultr/.goreleaser.yml
+++ b/vendor/github.com/JamesClonk/vultr/.goreleaser.yml
@@ -1,0 +1,48 @@
+# See https://goreleaser.com/ for details
+# Build customization
+build:
+  main: vultr.go
+  binary: vultr
+  env:
+    - CGO_ENABLED=0
+  goos:
+    - darwin
+    - linux
+    - windows
+    - freebsd
+    - netbsd
+    - openbsd
+    - dragonfly
+  goarch:
+    - amd64
+    - 386
+    - arm
+    - arm64
+  ignore:
+    - goos: openbsd
+      goarch: arm
+      goarm: 6
+
+archive:
+  format: tar.gz
+  format_overrides:
+    - goos: windows
+      format: zip
+  name_template: "{{.Binary}}_{{.Version}}_{{.Os}}-{{.Arch}}"
+  replacements:
+    amd64: 64bit
+    386: 32bit
+    arm: ARM
+    arm64: ARM64
+    darwin: macOS
+    linux: Linux
+    windows: Windows
+    openbsd: OpenBSD
+    netbsd: NetBSD
+    freebsd: FreeBSD
+    dragonfly: DragonFlyBSD
+  files:
+    - README.md
+    - LICENSE
+release:
+  draft: true

--- a/vendor/github.com/JamesClonk/vultr/.travis.yml
+++ b/vendor/github.com/JamesClonk/vultr/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.7
   - 1.8
+  - 1.9
   - tip
 env:
   - GOARCH=amd64

--- a/vendor/github.com/JamesClonk/vultr/Makefile
+++ b/vendor/github.com/JamesClonk/vultr/Makefile
@@ -1,25 +1,40 @@
-.PHONY: all prepare build lint vet test check release
+TEST?=$$(go list ./... |grep -v 'vendor')
+GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 
 all: prepare lint vet test build
 
 prepare:
 	go get -v github.com/golang/lint/golint
 	go get -v github.com/Masterminds/glide
+	go get -v github.com/goreleaser/goreleaser
 	glide install
 
 build:
-	GOARCH=amd64 GOOS=linux go install
+	go install
 
 lint:
-	for pkg in $$(go list ./... | grep -v /vendor/); do golint $$pkg; done
+	for pkg in $(TEST); do golint $$pkg; done
 
 vet:
-	GOARCH=amd64 GOOS=linux go vet $$(go list ./... | grep -v /vendor/)
+	@echo "go vet ."
+	@go vet $(TEST) ; if [ $$? -eq 1 ]; then \
+		echo ""; \
+		echo "Vet found suspicious constructs. Please check the reported constructs"; \
+		echo "and fix them if necessary before submitting the code for review."; \
+		exit 1; \
+	fi
+
+fmt:
+	gofmt -w $(GOFMT_FILES)
 
 test:
-	GOARCH=amd64 GOOS=linux go test $$(go list ./... | grep -v /vendor/)
+	go test -i $(TEST) || exit 1
+	echo $(TEST) | \
+		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 check: lint vet test
 
 release:
-	goxc -os="linux darwin windows freebsd openbsd" -tasks-=validate
+	goreleaser
+
+.PHONY: all prepare build lint vet test check release

--- a/vendor/github.com/JamesClonk/vultr/README.md
+++ b/vendor/github.com/JamesClonk/vultr/README.md
@@ -21,7 +21,7 @@ $ export VULTR_API_KEY=87dFbC91rJjkL/18zJEQxS
 * Run it
 ```sh
 $ vultr version
-Client version:         1.13.0
+Client version:         1.15.0
 Vultr API endpoint:     https://api.vultr.com/
 Vultr API version:      v1
 OS/Arch (client):       linux/amd64
@@ -46,7 +46,7 @@ $ export VULTR_API_KEY=89dFbb91rGjkL/12zJEQxS
 * Run it
 ```sh
 $ vultr version
-Client version:         1.13.0
+Client version:         1.15.0
 Vultr API endpoint:     https://api.vultr.com/
 Vultr API version:      v1
 OS/Arch (client):       linux/amd64

--- a/vultr/config.go
+++ b/vultr/config.go
@@ -2,10 +2,23 @@ package vultr
 
 import (
 	"log"
+	"net/http"
+	"net/http/httputil"
 	"time"
 
 	"github.com/JamesClonk/vultr/lib"
+	"github.com/hashicorp/terraform/helper/logging"
 )
+
+const logReqMsg = `Vultr API Request Details:
+---[ REQUEST ]---------------------------------------
+%s
+-----------------------------------------------------`
+
+const logRespMsg = `Vultr API Response Details:
+---[ RESPONSE ]--------------------------------------
+%s
+-----------------------------------------------------`
 
 // Config is the configuration structure used to instantiate the Vultr
 // provider.
@@ -21,6 +34,28 @@ type Client struct {
 // Client configures and returns a fully initialized Vultr Client.
 func (c *Config) Client() (interface{}, error) {
 	client := Client{lib.NewClient(c.APIKey, &lib.Options{RateLimitation: 500 * time.Millisecond})}
+
+	if logging.IsDebugOrHigher() {
+		client.OnRequestCompleted(logRequestAndResponse)
+	}
+
 	log.Printf("[INFO] Vultr Client configured for URL: %s", client.Endpoint)
+
 	return &client, nil
+}
+
+func logRequestAndResponse(req *http.Request, resp *http.Response) {
+	reqData, err := httputil.DumpRequest(req, true)
+	if err == nil {
+		log.Printf("[DEBUG] "+logReqMsg, string(reqData))
+	} else {
+		log.Printf("[ERROR] Vultr API Request error: %#v", err)
+	}
+
+	respData, err := httputil.DumpResponse(resp, true)
+	if err == nil {
+		log.Printf("[DEBUG] "+logRespMsg, string(respData))
+	} else {
+		log.Printf("[ERROR] Vultr API Response error: %#v", err)
+	}
 }


### PR DESCRIPTION
This allows to enable dumping of API calls into the Terraform debug logs, when setting the `TF_LOG` environment variable to `DEBUG`.

It depends of https://github.com/JamesClonk/vultr/pull/49 which introduces the needed hook.