### PR TITLE
vultr: add vultr_instance.ipv6_address attribute

### DIFF
--- a/vultr/resource_instance.go
+++ b/vultr/resource_instance.go
@@ -67,6 +67,12 @@ func resourceInstance() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"ipv6_address": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -223,6 +229,12 @@ func resourceInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("status", instance.Status)
 	d.Set("tag", instance.Tag)
 	d.Set("vcpus", instance.VCpus)
+
+	var ipv6s []string
+	for _, net := range instance.V6Networks {
+		ipv6s = append(ipv6s, net.MainIP)
+	}
+	d.Set("ipv6_address", ipv6s)
 
 	// Initialize the connection information.
 	d.SetConnInfo(map[string]string{


### PR DESCRIPTION
Note: this only makes the first address available, which is good enough for most cases. For cases that need more info, it should probably be another attribute with a different name.