### PR TITLE
Fixing Kubernetes example.

### DIFF
--- a/examples/kubernetes/bootkube.tf
+++ b/examples/kubernetes/bootkube.tf
@@ -1,5 +1,5 @@
 module "bootkube" {
-  source = "git://https://github.com/poseidon/terraform-render-bootkube.git?ref=v0.9.1"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=v0.9.1"
 
   cluster_name                  = "${var.cluster_name}"
   api_servers                   = ["${var.cluster_name}-api.${var.k8s_domain_name}"]

--- a/examples/kubernetes/bootkube.tf
+++ b/examples/kubernetes/bootkube.tf
@@ -7,5 +7,4 @@ module "bootkube" {
   asset_dir                     = "${var.asset_dir}"
   pod_cidr                      = "${var.pod_cidr}"
   service_cidr                  = "${var.service_cidr}"
-  experimental_self_hosted_etcd = true
 }


### PR DESCRIPTION
- Version 0.9.1 of `poseidon/terraform-render-bootkube` is not supporting option `experimental_self_hosted_etcd` anymore. (source: https://github.com/poseidon/terraform-render-bootkube/commit/ec48758c5e2ae75206564a8f2e347a8af5ee142b)
- Terraform is using a different `source` syntax for Git repositories. (source: https://www.terraform.io/docs/modules/sources.html#generic-git-repository)