### PR TITLE
Expose MACs of private networks in instance resource

### DIFF
--- a/vultr/resource_instance.go
+++ b/vultr/resource_instance.go
@@ -105,6 +105,12 @@ func resourceInstance() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
+			"network_macs": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
 			"notify_activate": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -278,9 +284,11 @@ func resourceInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error getting private networks for instance (%s): %v", d.Id(), err)
 	}
 	nets := make(map[string]string)
+	netMACs := make(map[string]string)
 	var networkIDs []string
 	for _, n := range networks {
 		nets[n.ID] = n.IPAddress
+		netMACs[n.ID] = n.MACAddress
 		networkIDs = append(networkIDs, n.ID)
 	}
 
@@ -319,6 +327,7 @@ func resourceInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("ipv4_private_cidr", fmt.Sprintf("%s/%d", instance.InternalIP, size))
 	d.Set("name", instance.Name)
 	d.Set("networks", nets)
+	d.Set("network_macs", netMACs)
 	d.Set("network_ids", networkIDs)
 	d.Set("os_id", osID)
 	d.Set("plan_id", instance.PlanID)


### PR DESCRIPTION
Terraform will support nested maps [starting with 0.12](https://www.hashicorp.com/blog/terraform-0-12-rich-value-types) (late summer). There's some l[imited support](https://github.com/jimmy-btn/terraform/commit/01be1a5ecd4a9788bd540cc1287b7d52a9cfb292) for nesting maps in lists (but not maps in maps), only one level deep. This is why I'm adding a separate map of MACs.

Fixes #54 