### PR TITLE
FillMap keys processing which have ',string'

### DIFF
--- a/vendor/github.com/fatih/structs/structs.go
+++ b/vendor/github.com/fatih/structs/structs.go
@@ -132,9 +132,9 @@ func (s *Struct) FillMap(out map[string]interface{}) {
 		}
 
 		if tagOpts.Has("string") {
-			s, ok := val.Interface().(fmt.Stringer)
-			if ok {
-				out[name] = s.String()
+			s := fmt.Sprintf("%v", val.Interface())
+			if s != "" {
+				out[name] = s
 			}
 			continue
 		}


### PR DESCRIPTION
Hi, thank you for providing such a good plugin.
When I executed 'terraform plan' using below, I met no-result error.
data "vultr_plan" "cheapest" {
  filter {
    name   = "price_per_month"
    values = ["5.00"]
  }
  filter {
    name   = "ram"
    values = ["1024"]
  }
 filter {
    name   = "vcpu_count"
    values = ["1"]
 }
}

I detected type conversion problem at FillMap method in fatih/struct/structs.go at vendor.

This is old source debugging.
[DEBUG] plugin.terraform-provider-vultr: 2019/06/16 22:09:59 name: VPSPLANID
[DEBUG] plugin.terraform-provider-vultr: 2019/06/16 22:09:59 s   : <nil>
[DEBUG] plugin.terraform-provider-vultr: 2019/06/16 22:09:59 name: vcpu_count
[DEBUG] plugin.terraform-provider-vultr: 2019/06/16 22:09:59 s   : <nil>

And new one.
[DEBUG] plugin.terraform-provider-vultr: 2019/06/16 22:32:29 name: VPSPLANID
[DEBUG] plugin.terraform-provider-vultr: 2019/06/16 22:32:29 s   : 201
[DEBUG] plugin.terraform-provider-vultr: 2019/06/16 22:32:29 name: vcpu_count
[DEBUG] plugin.terraform-provider-vultr: 2019/06/16 22:32:29 s   : 1

Other fields defined as plain integer type in 'Server' struct in vendor/JamesClonk/vultr/lib/servers.go also had same problem because of this.
Fatih's struct repository is archived, so I directly modified here.
